### PR TITLE
have a prelude for setting env vars for entrypoint

### DIFF
--- a/src/main/scala/Docker.scala
+++ b/src/main/scala/Docker.scala
@@ -97,14 +97,14 @@ object Docker {
           dockerAppDir / "banno-libs" / "*" :+
           dockerAppDir / "libs" / "*"
         ).mkString(":")
+      val entryPointLinePrelude = (entryPointPrelude in docker).value
       val entryPointLine =
-        Seq(
-          "bash",
-          "-c",
-          (entryPointPrelude in docker).value,
-          (Seq("java", "-cp", classpath) ++ javaArgs :+ main :+ "\"$@\"").mkString(" "),
-          "--"
-        )
+        Seq( "bash", "-c") :+ (
+          (if (entryPointLinePrelude.nonEmpty) Seq(entryPointLinePrelude) else Nil) ++
+          Seq("java", "-cp", classpath) ++ javaArgs :+ main :+ "\"$@\""
+        ).mkString(" ") :+
+        "--"
+
 
       new mutable.Dockerfile {
         otherCp.foreach    { depFile => stageFile(depFile, dockerAppDir / "libs" / depFile.name) }

--- a/src/main/scala/Docker.scala
+++ b/src/main/scala/Docker.scala
@@ -101,7 +101,7 @@ object Docker {
         Seq(
           "bash",
           "-c",
-          entryPointPrelude.value,
+          (entryPointPrelude in docker).value,
           (Seq("java", "-cp", classpath) ++ javaArgs :+ main :+ "\"$@\"").mkString(" "),
           "--"
         )

--- a/src/main/scala/Docker.scala
+++ b/src/main/scala/Docker.scala
@@ -18,6 +18,7 @@ object Docker {
   val appDir = SettingKey[File]("App directory within docker")
   val exposedPorts = SettingKey[Seq[Int]]("Exposed ports in docker")
 
+  val entryPointPrelude = SettingKey[String]("Additional ENV variables that need ran (in /bin/bash) before java process starts")
   val additionalRunCommands = SettingKey[Seq[String]]("Additional Run Commands to run during docker build")
   val command = SettingKey[Seq[String]]("Docker Default Command (usually arguments given to the java process)")
 
@@ -46,6 +47,7 @@ object Docker {
     (additionalRunCommands in docker) := Nil,
 
     command in docker := Nil,
+    entryPointPrelude in docker := "",
 
     // necessary to touch directories
     docker <<= (streams, dockerPath in docker, buildOptions in docker, stageDirectory in docker, dockerfile in docker, imageName in docker, appDir in docker) map {
@@ -99,6 +101,7 @@ object Docker {
         Seq(
           "bash",
           "-c",
+          entryPointPrelude.value,
           (Seq("java", "-cp", classpath) ++ javaArgs :+ main :+ "\"$@\"").mkString(" "),
           "--"
         )

--- a/src/sbt-test/banno-sbt-plugin/docker/build.sbt
+++ b/src/sbt-test/banno-sbt-plugin/docker/build.sbt
@@ -11,4 +11,6 @@ appDir in docker := file("/test")
 
 additionalRunCommands in docker := Seq("uname -a ", "whoami")
 
+entryPointPrelude in docker := "TEST_VAR=`echo -n test_env_var`"
+
 command in docker := Seq("testing", "arg1")

--- a/src/sbt-test/banno-sbt-plugin/docker/src/main/scala/Test.scala
+++ b/src/sbt-test/banno-sbt-plugin/docker/src/main/scala/Test.scala
@@ -1,5 +1,6 @@
 package com.banno
 
 object Test extends App {
-  println(s"${BuildInfo.name} - Ok - ${args(0)} - ${args(1)}")
+  val testEnvVar = sys.env("TEST_VAR")
+  println(s"${BuildInfo.name} - Ok - ${args(0)} - ${args(1)} - ${testEnvVar}")
 }

--- a/src/sbt-test/banno-sbt-plugin/docker/test
+++ b/src/sbt-test/banno-sbt-plugin/docker/test
@@ -1,4 +1,4 @@
 > docker
 $ exec /bin/bash -c 'docker images | grep -q registry.banno-internal.com/sbt-docker-test'
 $ exec /bin/bash -c "/bin/bash -c 'docker run -t registry.banno-internal.com/sbt-docker-test | grep -q 'sbt-docker-test - Ok - testing - arg1"
-$ exec /bin/bash -c "/bin/bash -c 'docker run -t registry.banno-internal.com/sbt-docker-test arg1 arg2 | grep -q 'sbt-docker-test - Ok - arg1 - arg2"
+$ exec /bin/bash -c "/bin/bash -c 'docker run -t registry.banno-internal.com/sbt-docker-test arg1 arg2 | grep -q 'sbt-docker-test - Ok - arg1 - arg2 - test_env_var"


### PR DESCRIPTION
Then things can be specified via

```scala
import Docker._

Docker.settings

entryPointPrelude in docker := "LIBPROCESS_IP=`ifconfig eth0 | awk '/inet addr/ {gsub(\"addr:\", \"\", $2); print $2}'`"
```