### PR TITLE
Samza base image

### DIFF
--- a/src/main/scala/Samza.scala
+++ b/src/main/scala/Samza.scala
@@ -7,7 +7,7 @@ import sbtdocker.Plugin.DockerKeys.docker
 object Samza {
   val settings = Docker.settings ++ Seq(
     mainClass in Compile := Some("com.banno.samza.Main"),
-    baseImage in docker := "banno/samza:latest",
+    baseImage in docker := "banno/samza:0.21.1-1",
     //Mesos native lib binds to LIBPROCESS_IP so the Mesos master can communicate with the Mesos framework, so it needs to be an IP accessible by Mesos master (not 127.0.0.1)
     entryPointPrelude in docker := "LIBPROCESS_IP=`ifconfig eth0 | awk '/inet addr/ {gsub(\"addr:\", \"\", $2); print $2}'`"
   )

--- a/src/main/scala/Samza.scala
+++ b/src/main/scala/Samza.scala
@@ -7,7 +7,7 @@ import sbtdocker.Plugin.DockerKeys.docker
 object Samza {
   val settings = Docker.settings ++ Seq(
     mainClass in Compile := Some("com.banno.samza.Main"),
-    baseImage in docker := "registry.banno-internal.com/mesos:0.21.0",
+    baseImage in docker := "banno/samza:latest",
     //Mesos native lib binds to LIBPROCESS_IP so the Mesos master can communicate with the Mesos framework, so it needs to be an IP accessible by Mesos master (not 127.0.0.1)
     entryPointPrelude in docker := "LIBPROCESS_IP=`ifconfig eth0 | awk '/inet addr/ {gsub(\"addr:\", \"\", $2); print $2}'`"
   )

--- a/src/main/scala/Samza.scala
+++ b/src/main/scala/Samza.scala
@@ -7,7 +7,7 @@ import sbtdocker.Plugin.DockerKeys.docker
 object Samza {
   val settings = Docker.settings ++ Seq(
     mainClass in Compile := Some("com.banno.samza.Main"),
-    baseImage in docker := "banno/samza:0.21.1-1",
+    baseImage in docker := "banno/samza-mesos:0.21.1",
     //Mesos native lib binds to LIBPROCESS_IP so the Mesos master can communicate with the Mesos framework, so it needs to be an IP accessible by Mesos master (not 127.0.0.1)
     entryPointPrelude in docker := "LIBPROCESS_IP=`ifconfig eth0 | awk '/inet addr/ {gsub(\"addr:\", \"\", $2); print $2}'`"
   )


### PR DESCRIPTION
Use a base Docker image specifically crafted for Samza jobs on Mesos, instead of re-purposing the base Mesos image. 

Uses our new automated build: https://registry.hub.docker.com/u/banno/samza-mesos/