### PR TITLE
use our published 3.1.0-java7 metrics-core

### DIFF
--- a/src/main/scala/deps.scala
+++ b/src/main/scala/deps.scala
@@ -105,7 +105,7 @@ object Metrics {
     libraryDependencies <++= (version, Akka.version) { (v, av) =>
       val msv = s"3.3.0_a${av.take(3)}" // https://github.com/erikvanoosten/metrics-scala#available-versions-abbreviated
       Seq(
-        "io.dropwizard.metrics" % "metrics-core"     % v,
+        "io.dropwizard.metrics" % "metrics-core"     % "3.1.0-java7", // until https://github.com/dropwizard/metrics/issues/742 is resolved
         "io.dropwizard.metrics" % "metrics-graphite" % v,
         "io.dropwizard.metrics" % "metrics-logback"  % v,
         "nl.grons" %% "metrics-scala"    % msv


### PR DESCRIPTION
Problem: 
This is the issue on dropwizard/metrics: https://github.com/dropwizard/metrics/issues/742.  Basically for us this means that `Thread`s were being kept around and our thread count was spiking when we were routing to just one stage.  As to why it was doing that... I'm not entirely sure, but it looked related to hbase connections.

Solution:
From the issue, just using the `java.util.concurrent.ThreadLocalRandom` from java 7.